### PR TITLE
Support updating old donations

### DIFF
--- a/db/migrations/20220824195743_old-ids-map.sql
+++ b/db/migrations/20220824195743_old-ids-map.sql
@@ -1,0 +1,24 @@
+-- migrate:up
+create view old_ids_map as
+select
+    p.id as donor_id,
+    p._old_id as old_donor_id,
+    d.id as donation_id,
+    d._old_id as old_donation_id,
+    c.id as charge_id,
+    c._old_id as old_charge_id
+from
+    _donor p
+    left join _donation d on p.id = d.donor_id
+    left join _charge c on d.id = c.donation_id
+where
+    p.deleted_at is null
+    and d.deleted_at is null
+    and c.deleted_at is null
+    and (p._old_id is not null
+        or d._old_id is not null
+        or c._old_id is not null);
+
+grant select on old_ids_map to reader;
+
+-- migrate:down

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -440,6 +440,23 @@ CREATE VIEW giveffektivt.kpi AS
 
 
 --
+-- Name: old_ids_map; Type: VIEW; Schema: giveffektivt; Owner: -
+--
+
+CREATE VIEW giveffektivt.old_ids_map AS
+ SELECT p.id AS donor_id,
+    p._old_id AS old_donor_id,
+    d.id AS donation_id,
+    d._old_id AS old_donation_id,
+    c.id AS charge_id,
+    c._old_id AS old_charge_id
+   FROM ((giveffektivt._donor p
+     LEFT JOIN giveffektivt._donation d ON ((p.id = d.donor_id)))
+     LEFT JOIN giveffektivt._charge c ON ((d.id = c.donation_id)))
+  WHERE ((p.deleted_at IS NULL) AND (d.deleted_at IS NULL) AND (c.deleted_at IS NULL) AND ((p._old_id IS NOT NULL) OR (d._old_id IS NOT NULL) OR (c._old_id IS NOT NULL)));
+
+
+--
 -- Name: recipient_distribution; Type: VIEW; Schema: giveffektivt; Owner: -
 --
 
@@ -619,4 +636,5 @@ INSERT INTO giveffektivt.schema_migrations (version) VALUES
     ('20220812002209'),
     ('20220812162001'),
     ('20220816152738'),
-    ('20220823110152');
+    ('20220823110152'),
+    ('20220824195743');

--- a/src/donation/repository.ts
+++ b/src/donation/repository.ts
@@ -126,3 +126,15 @@ export async function setDonationScanPayId(
     [donation.gateway_metadata?.scanpay_id, donation.id]
   );
 }
+
+export async function getDonationIdsByOldDonorId(
+  client: PoolClient,
+  old_donor_id: string
+): Promise<string[]> {
+  return (
+    await client.query(
+      "select donation_id from old_ids_map where old_donor_id = $1",
+      [old_donor_id]
+    )
+  ).rows.map((r) => r.donation_id);
+}

--- a/test/repository.ts
+++ b/test/repository.ts
@@ -6,7 +6,7 @@ import {
   DonationWithGatewayInfoScanPay,
   DonorWithSensitiveInfo,
 } from "../src";
-import { DonationWithGatewayInfoAny } from "./types";
+import { DonationWithGatewayInfoAny, DonorWithOldId } from "./types";
 
 export async function insertCharge(
   client: PoolClient,
@@ -69,4 +69,16 @@ export async function findAllCharges(
   client: PoolClient
 ): Promise<ChargeWithGatewayInfo[]> {
   return (await client.query(`select * from charge_with_gateway_info`)).rows;
+}
+
+export async function insertOldDonor(
+  client: PoolClient,
+  donor: Partial<DonorWithOldId>
+): Promise<DonorWithOldId> {
+  return (
+    await client.query(
+      `insert into _donor(email, _old_id) values ($1, $2) returning *`,
+      [donor.email, donor._old_id]
+    )
+  ).rows[0];
 }

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,5 +1,9 @@
-import { Donation } from "../src";
+import { Donation, DonorWithSensitiveInfo } from "../src";
 
 export type DonationWithGatewayInfoAny = Donation & {
   gateway_metadata: any;
+};
+
+export type DonorWithOldId = DonorWithSensitiveInfo & {
+  _old_id: string;
 };


### PR DESCRIPTION
When an old donation is updated (e.g. new credit card), ScanPay sends change.ref as donor ID in the old database.
This patch allows to find corresponding donation IDs to update in the new database.